### PR TITLE
Update vacuum pump control logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Originally developed for integration with the Zombie VCU, this project supports 
 
 - Tesla 3-way coolant valve
 - Coolant pump with RPM control (manual or auto mode)
-- Vacuum pump with hysteresis and warning detection
+- Vacuum pump with hysteresis and warning detection (active only in Ready state)
 - Voltage divider for analog signal monitoring
 - Digital IO pins for output control and sensor reading
 


### PR DESCRIPTION
## Summary
- ensure vacuum pump only runs when vehicle state is READY
- document READY state requirement in README

## Testing
- `make images` *(fails: arm-none-eabi-g++ not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a8f67f5c832bad73ccfa9bd248a5