### PR TITLE
Enable CAN2 clock

### DIFF
--- a/src/hwinit.cpp
+++ b/src/hwinit.cpp
@@ -56,8 +56,9 @@ void clock_setup(void)
    rcc_periph_clock_enable(RCC_DMA1);  //ADC, Encoder and UART receive
    rcc_periph_clock_enable(RCC_ADC1);
    rcc_periph_clock_enable(RCC_CRC);
-   rcc_periph_clock_enable(RCC_AFIO); //CAN
-   rcc_periph_clock_enable(RCC_CAN1); //CAN
+   rcc_periph_clock_enable(RCC_AFIO); // CAN
+   rcc_periph_clock_enable(RCC_CAN1); // CAN1
+   rcc_periph_clock_enable(RCC_CAN2); // CAN2
 }
 
 /* Some pins should never be left floating at any time


### PR DESCRIPTION
## Summary
- configure RCC to power CAN2 peripheral

## Testing
- `make` *(fails: arm-none-eabi-g++ not found)*
- `make Test` *(fails: can't cd to test)*

------
https://chatgpt.com/codex/tasks/task_e_6849fc2b4b18832b85840088f029d185