### PR TITLE
Fix comments and doc typos

### DIFF
--- a/include/bms.h
+++ b/include/bms.h
@@ -32,7 +32,7 @@
  * function to return whether charging is permitted and the maximum
  * charge current.
  * The function Task100Ms() will be called every 100ms and should
- * be used to implement a timeout for receiving fata from the BMS.
+ * be used to implement a timeout for receiving data from the BMS.
  */
 
 class BMS

--- a/include/digio_prj.h
+++ b/include/digio_prj.h
@@ -6,7 +6,7 @@
 /* Here you specify generic IO pins, i.e. digital input or outputs.
  * Inputs can be floating (INPUT_FLT), have a 30k pull-up (INPUT_PU)
  * or pull-down (INPUT_PD) or be an output (OUTPUT)
- * !!Pull-Up dows not work on zombie, because externaly pulled down!! */
+ * !!Pull-Up does not work on Zombie because externally pulled down!! */
 
 #define DIG_IO_LIST                                                             \
     DIG_IO_ENTRY(led_out, GPIOE, GPIO2, PinMode::OUTPUT)                        \

--- a/vehicle states.md
+++ b/vehicle states.md
@@ -9,7 +9,7 @@
 | 🚗 **Drive**       | ✅          | ✅                   | ✅            | ✅            | BMS + Inverter     | Full driving mode. Torque delivery enabled. Requires ignition ON, brake pressed, and completed start sequence. |
 | ⚡ **Charge**      | ✅          | ✅                   | ❌            | ✅            | BMS only           | Charging via AC or DC. Drive disabled. On finish, system exits to Conditioning for cooling. |
 | ⚠️ **Error**       | ✅          | ❌                   | ❌            | ❌            | —                  | Fault state. HV and torque disabled. Awaiting 12V power cycle to reset and reboot safely. |
-| 🛠️ **Limp Home**   | ✅          | ✅                   | ✅            | ✅            | BMS + Inverter     | Degraded fault state. HV and limited drive allowed. Used when faults permit continued low-performance operation. Can exit to Conditioning. Important, because Tesla SDU does't allow HV power of.|
+| 🛠️ **Limp Home**   | ✅          | ✅                   | ✅            | ✅            | BMS + Inverter     | Degraded fault state. HV and limited drive allowed. Used when faults permit continued low-performance operation. Can exit to Conditioning. Important because the Tesla SDU doesn't allow HV power off.|
 
 ---
 


### PR DESCRIPTION
## Summary
- fix comment about digital IO pull-up
- fix BMS comment wording
- clarify Tesla SDU power off note in vehicle states docs

## Testing
- `make` *(fails: arm-none-eabi-g++ not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ff2558d4832b9ba9866bdb1eb88b