### PR TITLE
Fix CAN interface null pointer handling

### DIFF
--- a/src/teensyBMS.cpp
+++ b/src/teensyBMS.cpp
@@ -3,6 +3,11 @@
 #include <string.h>
 
 void TeensyBMS::SetCanInterface(CanHardware* c) {
+    if (c == nullptr) {
+        can = nullptr;
+        return;
+    }
+
     can = c;
     can->RegisterUserMessage(0x41A); // 1050: Pack state
     can->RegisterUserMessage(0x41B); // 1051: Voltage info

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,19 @@
+CXX=g++
+CXXFLAGS=-std=c++11 -I../include -I./stubs
+
+all: run
+
+run: test_teensyBMS
+	./test_teensyBMS
+
+test_teensyBMS: test_teensyBMS.o ../src/teensyBMS.o
+	$(CXX) $(CXXFLAGS) $^ -o $@
+
+../src/teensyBMS.o: ../src/teensyBMS.cpp
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+test_teensyBMS.o: test_teensyBMS.cpp
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+clean:
+	rm -f test_teensyBMS *.o ../src/teensyBMS.o

--- a/test/stubs/canhardware.h
+++ b/test/stubs/canhardware.h
@@ -1,0 +1,8 @@
+#ifndef CANHARDWARE_H
+#define CANHARDWARE_H
+class CanHardware {
+public:
+    virtual ~CanHardware() = default;
+    virtual void RegisterUserMessage(int) {}
+};
+#endif

--- a/test/stubs/params.h
+++ b/test/stubs/params.h
@@ -1,0 +1,38 @@
+#ifndef PARAMS_H
+#define PARAMS_H
+class Param {
+public:
+    enum {
+        BMS_ChargeLim,
+        BMS_Vmin,
+        BMS_Vmax,
+        BMS_Tmin,
+        BMS_Tmax,
+        BMS_PackVoltage,
+        BMS_DeltaCellVoltage,
+        BMS_BalancingVoltage,
+        BMS_BalancingActive,
+        BMS_BalancingAnyActive,
+        BMS_ActualCurrent,
+        BMS_SOC,
+        BMS_PackPower,
+        BMS_State,
+        BMS_DTC,
+        BMS_TimeoutFault,
+        BMS_MaxChargeCurrent,
+        BMS_MaxDischargeCurrent,
+        BMS_ShutdownRequest,
+        BMS_ShutdownReady,
+        BMS_ShutdownAcknowledge,
+        BMS_DataValid,
+        BMS_CONT_State,
+        BMS_CONT_DTC,
+        BMS_CONT_NegativeInput,
+        BMS_CONT_PositiveInput,
+        BMS_CONT_PrechargeInput,
+        BMS_CONT_SupplyVoltageAvailable
+    };
+    static void SetFloat(int, float) {}
+    static void SetInt(int, int) {}
+};
+#endif

--- a/test/test_teensyBMS.cpp
+++ b/test/test_teensyBMS.cpp
@@ -1,0 +1,29 @@
+#include "teensyBMS.h"
+#include <cassert>
+
+class MockCanHardware : public CanHardware {
+public:
+    int count = 0;
+    void RegisterUserMessage(int) override { count++; }
+};
+
+class TestTeensyBMS : public TeensyBMS {
+public:
+    CanHardware* GetCan() const { return can; }
+};
+
+int main() {
+    {
+        TestTeensyBMS bms;
+        bms.SetCanInterface(nullptr);
+        assert(bms.GetCan() == nullptr);
+    }
+    {
+        TestTeensyBMS bms;
+        MockCanHardware can;
+        bms.SetCanInterface(&can);
+        assert(bms.GetCan() == &can);
+        assert(can.count == 7);
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- avoid dereferencing nullptr in `TeensyBMS::SetCanInterface`
- add simple unit test to verify correct behaviour

## Testing
- `make Test`

------
https://chatgpt.com/codex/tasks/task_e_684a021f1da0832b907bffff0d4f4aeb