### PR TITLE
Add VCU status feedback every cycle

### DIFF
--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -158,6 +158,10 @@
    VALUE_ENTRY(LVDU_vcu_out, "On/Off", 2158)                                              \
    VALUE_ENTRY(LVDU_condition_out, "On/Off", 2159)                                        \
    VALUE_ENTRY(LVDU_ready_out, "On/Off", 2160)
+         \
+   VALUE_ENTRY(LVDU_forceVCUsShutdown, "On/Off", 2161)
+         \
+   VALUE_ENTRY(LVDU_connectHVcommand, "On/Off", 2162)
 
 /***** Enum String definitions *****/
 #define OPMODES "0=Off, 1=Run, 2=Precharge, 3=PchFail, 4=Charge"

--- a/src/teensyBMS.cpp
+++ b/src/teensyBMS.cpp
@@ -2,6 +2,21 @@
 #include "params.h"
 #include <string.h>
 
+// CAN message ID for VCU -> BMS feedback
+#define VCU_STATUS_MSG_ID 0x437
+
+/*
+Shutdown sequence (simplified)
+------------------------------
+
+ BMS        VCU       Contactors
+  |--0x41F: request-->|
+  |<--0x437: status---|
+  |                   |--open HV
+  |<--0x41F: ready----|
+  |--0x41F: ack------>|
+*/
+
 void TeensyBMS::SetCanInterface(CanHardware* c) {
     if (c == nullptr) {
         can = nullptr;
@@ -119,4 +134,14 @@ void TeensyBMS::Task100Ms() {
     Param::SetInt(Param::BMS_CONT_PositiveInput, contactorPositiveInput);
     Param::SetInt(Param::BMS_CONT_PrechargeInput, contactorPrechargeInput);
     Param::SetInt(Param::BMS_CONT_SupplyVoltageAvailable, contactorSupplyAvailable);
+
+    // Send VCU status back to the BMS every cycle (100ms)
+    if (can) {
+        uint8_t bytes[3] = {
+            static_cast<uint8_t>(Param::GetInt(Param::LVDU_vehicle_state)),
+            static_cast<uint8_t>(Param::GetInt(Param::LVDU_forceVCUsShutdown)),
+            static_cast<uint8_t>(Param::GetInt(Param::LVDU_connectHVcommand))};
+        can->Send(VCU_STATUS_MSG_ID, bytes, 3);
+    }
 }
+

--- a/test/Makefile
+++ b/test/Makefile
@@ -6,13 +6,16 @@ all: run
 run: test_teensyBMS
 	./test_teensyBMS
 
-test_teensyBMS: test_teensyBMS.o ../src/teensyBMS.o
+test_teensyBMS: test_teensyBMS.o params.o ../src/teensyBMS.o
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
 ../src/teensyBMS.o: ../src/teensyBMS.cpp
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 test_teensyBMS.o: test_teensyBMS.cpp
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+params.o: stubs/params.cpp
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 clean:

--- a/test/stubs/canhardware.h
+++ b/test/stubs/canhardware.h
@@ -4,5 +4,6 @@ class CanHardware {
 public:
     virtual ~CanHardware() = default;
     virtual void RegisterUserMessage(int) {}
+    virtual void Send(int, uint8_t*, int) {}
 };
 #endif

--- a/test/stubs/params.cpp
+++ b/test/stubs/params.cpp
@@ -1,0 +1,2 @@
+#include "params.h"
+int Param::values[64] = {0};

--- a/test/stubs/params.h
+++ b/test/stubs/params.h
@@ -30,9 +30,18 @@ public:
         BMS_CONT_NegativeInput,
         BMS_CONT_PositiveInput,
         BMS_CONT_PrechargeInput,
-        BMS_CONT_SupplyVoltageAvailable
+        BMS_CONT_SupplyVoltageAvailable,
+        LVDU_vehicle_state,
+        LVDU_forceVCUsShutdown,
+        LVDU_connectHVcommand
     };
     static void SetFloat(int, float) {}
-    static void SetInt(int, int) {}
+    static void SetInt(int idx, int val) { values[idx] = val; }
+    static int  GetInt(int idx) { return values[idx]; }
+
+private:
+    static int values[64];
 };
+
+// Storage for parameters will be defined in params.cpp
 #endif

--- a/test/test_teensyBMS.cpp
+++ b/test/test_teensyBMS.cpp
@@ -5,6 +5,15 @@ class MockCanHardware : public CanHardware {
 public:
     int count = 0;
     void RegisterUserMessage(int) override { count++; }
+    int sendCount = 0;
+    int lastId = 0;
+    uint8_t lastData[3] = {0};
+    void Send(int id, uint8_t* data, int) override {
+        sendCount++; lastId = id;
+        lastData[0] = data[0];
+        lastData[1] = data[1];
+        lastData[2] = data[2];
+    }
 };
 
 class TestTeensyBMS : public TeensyBMS {
@@ -24,6 +33,18 @@ int main() {
         bms.SetCanInterface(&can);
         assert(bms.GetCan() == &can);
         assert(can.count == 7);
+
+        Param::SetInt(Param::LVDU_vehicle_state, 3);
+        Param::SetInt(Param::LVDU_forceVCUsShutdown, 1);
+        Param::SetInt(Param::LVDU_connectHVcommand, 0);
+        for (int i = 0; i < 5; ++i)
+            bms.Task100Ms();
+
+        assert(can.sendCount == 5);
+        assert(can.lastId == 0x437);
+        assert(can.lastData[0] == 3);
+        assert(can.lastData[1] == 1);
+        assert(can.lastData[2] == 0);
     }
     return 0;
 }


### PR DESCRIPTION
## Summary
- rename parameter to `LVDU_connectHVcommand`
- transmit VCU status on each 100 ms cycle
- document shutdown sequence in `teensyBMS.cpp`
- adjust unit test for new period and parameter name

## Testing
- `make -C test`


------
https://chatgpt.com/codex/tasks/task_e_684b506a1af4832b983af52521da2b54