### PR TITLE
Add debug parameters for TeensyBMS CAN functions

### DIFF
--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -132,6 +132,10 @@
    VALUE_ENTRY(BMS_CONT_PositiveInput, "On/Off", 2225)                                    \
    VALUE_ENTRY(BMS_CONT_PrechargeInput, "On/Off", 2226)                                   \
    VALUE_ENTRY(BMS_CONT_SupplyVoltageAvailable, "On/Off", 2227)                           \
+   VALUE_ENTRY(BMS_SetCanInterfaceCalled, YESNO, 2228)\
+          \
+   VALUE_ENTRY(BMS_DecodeCanCalled, YESNO, 2229)\
+          \
                                                                                           \
    PARAM_ENTRY(CAT_HEATER, heater_flap_threshold, "Raw ADC", 0, 4095, 1000, 113)          \
    PARAM_ENTRY(CAT_HEATER, heater_active_manual, "0=Auto, 1=ManualON", 0, 1, 0, 111)     \

--- a/src/teensyBMS.cpp
+++ b/src/teensyBMS.cpp
@@ -31,9 +31,12 @@ void TeensyBMS::SetCanInterface(CanHardware* c) {
     can->RegisterUserMessage(0x41E); // 1054: Charge/discharge limits
     can->RegisterUserMessage(0x41F); // 1055: Shutdown handshake
     can->RegisterUserMessage(0x438); // 1080: Contactor manager state
+
+    Param::SetInt(Param::BMS_SetCanInterfaceCalled, 1);
 }
 
 void TeensyBMS::DecodeCAN(int id, uint8_t* data) {
+    Param::SetInt(Param::BMS_DecodeCanCalled, 1);
     switch (id) {
         case 0x41A: parseMessage41A(data); break;
         case 0x41B: parseMessage41B(data); break;

--- a/test/stubs/params.h
+++ b/test/stubs/params.h
@@ -31,6 +31,8 @@ public:
         BMS_CONT_PositiveInput,
         BMS_CONT_PrechargeInput,
         BMS_CONT_SupplyVoltageAvailable,
+        BMS_SetCanInterfaceCalled,
+        BMS_DecodeCanCalled,
         LVDU_vehicle_state,
         LVDU_forceVCUsShutdown,
         LVDU_connectHVcommand


### PR DESCRIPTION
## Summary
- add runtime flags to show if TeensyBMS SetCanInterface and DecodeCAN were called
- expose the new flags in parameter stubs for unit tests
- set the flags in TeensyBMS implementation

## Testing
- `cd test && make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_684caaa92068832b8e72ef4d5e11f900