### PR TITLE
Fix heater comfort functions flag

### DIFF
--- a/include/heater.h
+++ b/include/heater.h
@@ -90,7 +90,7 @@ public:
         int flap_signal       = Param::GetInt(Param::valve_in_raw);
         int flap_threshold    = Param::GetInt(Param::heater_flap_threshold);
         bool manual_override  = Param::GetInt(Param::heater_active_manual);
-        bool comfort_allowed  = true; // todo Param::GetInt(Param::hv_comfort_functions_allowed);
+        bool comfort_allowed  = Param::GetInt(Param::hv_comfort_functions_allowed);
         bool thermal_closed   = DigIo::heater_thermal_switch_in.Get(); // High = closed
         bool contactor_feedback = (DigIo::heater_contactor_feedback_in.Get() == 1); 
         bool contactor_out      = (DigIo::heater_contactor_out.Get() == 1);         

--- a/include/lvdu.h
+++ b/include/lvdu.h
@@ -386,6 +386,9 @@ private:
         Param::SetInt(Param::LVDU_condition_out, DigIo::condition_out.Get() ? 1 : 0);
         Param::SetInt(Param::LVDU_ready_out, DigIo::ready_out.Get() ? 1 : 0);
 
+        // For now comfort functions are always permitted
+        Param::SetInt(Param::hv_comfort_functions_allowed, 1);
+
         int connectHV = 0;
         if (state == STATE_READY || state == STATE_CONDITIONING ||
             state == STATE_DRIVE || state == STATE_CHARGE ||

--- a/test/stubs/params.h
+++ b/test/stubs/params.h
@@ -35,7 +35,8 @@ public:
         BMS_DecodeCanCalled,
         LVDU_vehicle_state,
         LVDU_forceVCUsShutdown,
-        LVDU_connectHVcommand
+        LVDU_connectHVcommand,
+        hv_comfort_functions_allowed
     };
     static void SetFloat(int, float) {}
     static void SetInt(int idx, int val) { values[idx] = val; }


### PR DESCRIPTION
## Summary
- consume lvdu parameter `hv_comfort_functions_allowed` instead of a hardcoded value
- always set the parameter to `true` in `LVDU`
- extend param stub with the new enumeration

## Testing
- `make -C test`

------
https://chatgpt.com/codex/tasks/task_e_684cb243604c832bba8a1c49d8c67fdb