### PR TITLE
Track last BMS CAN ID

### DIFF
--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -132,6 +132,8 @@
    VALUE_ENTRY(BMS_SetCanInterfaceCalled, YESNO, 2228)                                    \
                                                                                           \
    VALUE_ENTRY(BMS_DecodeCanCalled, YESNO, 2229)                                          \
+   VALUE_ENTRY(BMS_LastCanId, "", 2230)
+          \
                                                                                           \
    PARAM_ENTRY(CAT_HEATER, heater_flap_threshold, "Raw ADC", 0, 4095, 1000, 113)          \
    PARAM_ENTRY(CAT_HEATER, heater_active_manual, "0=Auto, 1=ManualON", 0, 1, 0, 111)      \

--- a/src/teensyBMS.cpp
+++ b/src/teensyBMS.cpp
@@ -37,6 +37,7 @@ void TeensyBMS::SetCanInterface(CanHardware* c) {
 
 void TeensyBMS::DecodeCAN(int id, uint8_t* data) {
     Param::SetInt(Param::BMS_DecodeCanCalled, 1);
+    Param::SetInt(Param::BMS_LastCanId, id);
     switch (id) {
         case 0x41A: parseMessage41A(data); break;
         case 0x41B: parseMessage41B(data); break;

--- a/test/stubs/params.h
+++ b/test/stubs/params.h
@@ -33,6 +33,7 @@ public:
         BMS_CONT_SupplyVoltageAvailable,
         BMS_SetCanInterfaceCalled,
         BMS_DecodeCanCalled,
+        BMS_LastCanId,
         LVDU_vehicle_state,
         LVDU_forceVCUsShutdown,
         LVDU_connectHVcommand,

--- a/test/test_teensyBMS.cpp
+++ b/test/test_teensyBMS.cpp
@@ -45,6 +45,14 @@ int main() {
         assert(can.lastData[0] == 3);
         assert(can.lastData[1] == 1);
         assert(can.lastData[2] == 0);
+
+        // Test DecodeCAN updates parameters
+        Param::SetInt(Param::BMS_DecodeCanCalled, 0);
+        Param::SetInt(Param::BMS_LastCanId, 0);
+        uint8_t data[8] = {0};
+        bms.DecodeCAN(0x41A, data);
+        assert(Param::GetInt(Param::BMS_DecodeCanCalled) == 1);
+        assert(Param::GetInt(Param::BMS_LastCanId) == 0x41A);
     }
     return 0;
 }


### PR DESCRIPTION
## Summary
- record last CAN ID received for TeensyBMS
- expose new `BMS_LastCanId` value parameter
- update tests to cover new functionality

## Testing
- `cd test && make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_6858599ba39c832b855d0e5a707fdbea