### PR TITLE
Implement final Teensy BMS CAN format

### DIFF
--- a/include/teensyBMS.h
+++ b/include/teensyBMS.h
@@ -15,13 +15,12 @@ public:
     void Task100Ms() override;
 
 private:
-    void parseMessage41A(uint8_t* data);
-    void parseMessage41B(uint8_t* data);
-    void parseMessage41C(uint8_t* data);
-    void parseMessage41D(uint8_t* data);
-    void parseMessage41E(uint8_t* data);
-    void parseMessage41F(uint8_t* data);
-    void parseMessage438(uint8_t* data);
+    void parseMsg1(uint8_t* data);
+    void parseMsg2(uint8_t* data);
+    void parseMsg3(uint8_t* data);
+    void parseMsg4(uint8_t* data);
+    void parseMsg5(uint8_t* data);
+    bool checkCrc(uint8_t* data);
 
     int timeoutCounter = 0;
 
@@ -55,6 +54,8 @@ private:
     bool contactorPositiveInput = false;
     bool contactorPrechargeInput = false;
     bool contactorSupplyAvailable = false;
+
+    uint8_t txCounter = 0;
 };
 
 #endif // TEENSYBMS_H

--- a/src/teensyBMS.cpp
+++ b/src/teensyBMS.cpp
@@ -1,6 +1,7 @@
 #include "teensyBMS.h"
 #include "params.h"
 #include <string.h>
+#include <libopencm3/stm32/crc.h>
 
 // CAN message ID for VCU -> BMS feedback
 #define VCU_STATUS_MSG_ID 0x437
@@ -24,13 +25,11 @@ void TeensyBMS::SetCanInterface(CanHardware* c) {
     }
 
     can = c;
-    can->RegisterUserMessage(0x41A); // 1050: Pack state
-    can->RegisterUserMessage(0x41B); // 1051: Voltage info
-    can->RegisterUserMessage(0x41C); // 1052: Temperatures
-    can->RegisterUserMessage(0x41D); // 1053: Current + SOC
-    can->RegisterUserMessage(0x41E); // 1054: Charge/discharge limits
-    can->RegisterUserMessage(0x41F); // 1055: Shutdown handshake
-    can->RegisterUserMessage(0x438); // 1080: Contactor manager state
+    can->RegisterUserMessage(0x41A); // MSG1: Voltage
+    can->RegisterUserMessage(0x41B); // MSG2: Cell Temp
+    can->RegisterUserMessage(0x41C); // MSG3: Limits/Fault
+    can->RegisterUserMessage(0x41D); // MSG4: SOC/SOH
+    can->RegisterUserMessage(0x41E); // MSG5: HMI
 
     Param::SetInt(Param::BMS_SetCanInterfaceCalled, 1);
 }
@@ -40,61 +39,63 @@ void TeensyBMS::DecodeCAN(int id, uint8_t* data) {
     Param::SetInt(Param::BMS_LastCanId, id);
     Param::SetInt(Param::BMS_DecodeCanCalled, 1);
     switch (id) {
-        case 0x41A: parseMessage41A(data); break;
-        case 0x41B: parseMessage41B(data); break;
-        case 0x41C: parseMessage41C(data); break;
-        case 0x41D: parseMessage41D(data); break;
-        case 0x41E: parseMessage41E(data); break;
-        case 0x41F: parseMessage41F(data); break;
-        case 0x438: parseMessage438(data); break;
+        case 0x41A: parseMsg1(data); break;
+        case 0x41B: parseMsg2(data); break;
+        case 0x41C: parseMsg3(data); break;
+        case 0x41D: parseMsg4(data); break;
+        case 0x41E: parseMsg5(data); break;
     }
 }
 
-void TeensyBMS::parseMessage41A(uint8_t* d) {
-    state = d[0];
-    dtc = d[1];
-    balancingVoltage = (d[2] | (d[3] << 8)) * 0.001f;
-    balancingActive = d[4] & 0x01;
-    anyBalancing = (d[4] >> 1) & 0x01;
+bool TeensyBMS::checkCrc(uint8_t* d) {
+    uint32_t buf[2];
+    memcpy(buf, d, 8);
+    buf[1] &= 0x00FFFFFF; // clear CRC byte
+    crc_reset();
+    uint32_t crc = crc_calculate_block(buf, 2) & 0xFF;
+    return crc == d[7];
+}
+
+void TeensyBMS::parseMsg1(uint8_t* d) {
+    if (!checkCrc(d)) return;
+    packVoltage = (d[0] | (d[1] << 8)) / 10.0f;
+    actualCurrent = ((int16_t)(d[2] | (d[3] << 8)) - 5000) / 10.0f;
+    vMin = d[4] / 50.0f;
+    vMax = d[5] / 50.0f;
     timeoutCounter = BMS_TIMEOUT_TICKS;
 }
 
-void TeensyBMS::parseMessage41B(uint8_t* d) {
-    vMin = (d[0] | (d[1] << 8)) * 0.001f;
-    vMax = (d[2] | (d[3] << 8)) * 0.001f;
-    packVoltage = (d[4] | (d[5] << 8)) * 0.01f;
-    deltaVoltage = (d[6] | (d[7] << 8)) * 0.001f;
+void TeensyBMS::parseMsg2(uint8_t* d) {
+    if (!checkCrc(d)) return;
+    tMin = d[0] - 40;
+    tMax = d[1] - 40;
+    balancingVoltage = d[2] / 50.0f;
+    deltaVoltage = d[3] / 100.0f;
+    int16_t raw = d[4] | (d[5] << 8);
+    float kw = (raw - 2000) / 10.0f;
+    packPower = kw * 1000.0f;
 }
 
-void TeensyBMS::parseMessage41C(uint8_t* d) {
-    tMin = (int16_t)(d[0] | (d[1] << 8)) - 40;
-    tMax = (int16_t)(d[2] | (d[3] << 8)) - 40;
+void TeensyBMS::parseMsg3(uint8_t* d) {
+    if (!checkCrc(d)) return;
+    maxDischargeCurrent = (d[0] | (d[1] << 8)) / 10.0f;
+    maxChargeCurrent = (d[2] | (d[3] << 8)) / 10.0f;
+    contactorState = d[4];
+    dtc = d[5];
 }
 
-void TeensyBMS::parseMessage41D(uint8_t* d) {
-    actualCurrent = (int16_t)(d[0] | (d[1] << 8)) * 0.1f;
-    soc = (d[2] | (d[3] << 8)) * 0.1f;
-    packPower = d[4] | (d[5] << 8);
+void TeensyBMS::parseMsg4(uint8_t* d) {
+    if (!checkCrc(d)) return;
+    soc = (d[0] | (d[1] << 8)) / 100.0f;
+    // soh not used
+    balancingActive = d[4];
+    anyBalancing = balancingActive != 0;
+    state = d[5];
 }
 
-void TeensyBMS::parseMessage41E(uint8_t* d) {
-    maxChargeCurrent = (d[0] | (d[1] << 8)) * 0.1f;
-    maxDischargeCurrent = (d[2] | (d[3] << 8)) * 0.1f;
-}
-
-void TeensyBMS::parseMessage41F(uint8_t* d) {
-    shutdownRequest = d[0];
-    shutdownReady = d[1];
-    shutdownAck = d[2];
-}
-
-void TeensyBMS::parseMessage438(uint8_t* d) {
-    contactorState = d[0];
-    contactorDTC = d[1];
-    contactorNegativeInput = d[2] & 0x01;
-    contactorPositiveInput = d[3] & 0x01;
-    contactorPrechargeInput = d[4] & 0x01;
-    contactorSupplyAvailable = d[5] & 0x01;
+void TeensyBMS::parseMsg5(uint8_t* d) {
+    if (!checkCrc(d)) return;
+    // energy per hour and time to full currently unused
 }
 
 float TeensyBMS::MaxChargeCurrent() {
@@ -142,11 +143,19 @@ void TeensyBMS::Task100Ms() {
 
     // Send VCU status back to the BMS every cycle (100ms)
     if (can) {
-        uint8_t bytes[3] = {
-            static_cast<uint8_t>(Param::GetInt(Param::LVDU_vehicle_state)),
-            static_cast<uint8_t>(Param::GetInt(Param::LVDU_forceVCUsShutdown)),
-            static_cast<uint8_t>(Param::GetInt(Param::LVDU_connectHVcommand))};
-        can->Send(VCU_STATUS_MSG_ID, bytes, 3);
+        uint8_t bytes[8] = {0};
+        bytes[0] = static_cast<uint8_t>(Param::GetInt(Param::LVDU_vehicle_state));
+        bytes[1] = static_cast<uint8_t>(Param::GetInt(Param::LVDU_forceVCUsShutdown));
+        bytes[2] = static_cast<uint8_t>(Param::GetInt(Param::LVDU_connectHVcommand));
+        bytes[3] = txCounter & 0x0F;
+        uint32_t word = 0;
+        memcpy(&word, bytes, sizeof(word));
+        crc_reset();
+        uint32_t crc = crc_calculate_block(&word, 1) & 0xFF;
+        bytes[4] = crc;
+        can->Send(VCU_STATUS_MSG_ID, bytes, 8);
+        // bytes[5..7] stay zero
+        txCounter = (txCounter + 1) & 0x0F;
     }
 }
 

--- a/test/stubs/libopencm3/stm32/crc.h
+++ b/test/stubs/libopencm3/stm32/crc.h
@@ -1,0 +1,9 @@
+#ifndef LIBOPENCM3_STM32_CRC_H
+#define LIBOPENCM3_STM32_CRC_H
+#include <stdint.h>
+static inline void crc_reset(void) {}
+static inline uint32_t crc_calculate_block(const uint32_t *buf, uint32_t len)
+{
+    (void)buf; (void)len; return 0;
+}
+#endif

--- a/test/test_teensyBMS.cpp
+++ b/test/test_teensyBMS.cpp
@@ -7,12 +7,12 @@ public:
     void RegisterUserMessage(int) override { count++; }
     int sendCount = 0;
     int lastId = 0;
-    uint8_t lastData[3] = {0};
-    void Send(int id, uint8_t* data, int) override {
-        sendCount++; lastId = id;
-        lastData[0] = data[0];
-        lastData[1] = data[1];
-        lastData[2] = data[2];
+    uint8_t lastData[8] = {0};
+    int lastLen = 0;
+    void Send(int id, uint8_t* data, int len) override {
+        sendCount++; lastId = id; lastLen = len;
+        for (int i = 0; i < len && i < 8; ++i)
+            lastData[i] = data[i];
     }
 };
 
@@ -32,7 +32,7 @@ int main() {
         MockCanHardware can;
         bms.SetCanInterface(&can);
         assert(bms.GetCan() == &can);
-        assert(can.count == 7);
+        assert(can.count == 5);
 
         Param::SetInt(Param::LVDU_vehicle_state, 3);
         Param::SetInt(Param::LVDU_forceVCUsShutdown, 1);
@@ -42,9 +42,12 @@ int main() {
 
         assert(can.sendCount == 5);
         assert(can.lastId == 0x437);
+        assert(can.lastLen == 8);
         assert(can.lastData[0] == 3);
         assert(can.lastData[1] == 1);
         assert(can.lastData[2] == 0);
+        assert(can.lastData[3] == 4);
+        assert(can.lastData[4] == 0); // CRC from stub
 
         // Test DecodeCAN updates parameters
         Param::SetInt(Param::BMS_DecodeCanCalled, 0);


### PR DESCRIPTION
## Summary
- update TeensyBMS CAN parser for new 8‑byte messages
- compute CRC8 using libopencm3 CRC
- transmit VCU status with counter and CRC
- add stubbed CRC header for unit tests
- adjust unit tests for new format

## Testing
- `make -C test`

------
https://chatgpt.com/codex/tasks/task_e_68756e2a4b4c832b892177058947fa84