### PR TITLE
Implement low-voltage VCU shutdown

### DIFF
--- a/include/lvdu.h
+++ b/include/lvdu.h
@@ -72,6 +72,7 @@ public:
         UpdateState();
         HandleReadyDiagnosis();
         UpdateOutputs();
+        HandleLow12V();
         UpdateParams();
     }
 
@@ -387,6 +388,18 @@ private:
             DigIo::condition_out.Set();
             DigIo::ready_out.Set();
             break;
+        }
+    }
+
+    void HandleLow12V()
+    {
+        if (state != STATE_READY && state != STATE_DRIVE && state != STATE_LIMP_HOME)
+        {
+            float threshold = Param::GetFloat(Param::LVDU_12v_low_threshold);
+            if (voltage12V < threshold)
+            {
+                DigIo::vcu_out.Clear();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- add handler to disable VCU output when 12V supply drops below limit
- call new handler from the periodic task so it runs each cycle

## Testing
- `make Test`
- `make` *(fails: `arm-none-eabi-g++: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68756e9e6358832b8d4eb3e540b9485d