### PR TITLE
Prevent HV request hang and add CAN decode metrics

### DIFF
--- a/include/lvdu.h
+++ b/include/lvdu.h
@@ -127,12 +127,36 @@ private:
         // Wait for HV contactor acknowledgment before entering HV states
         if (hvRequestPending)
         {
-            if (hvContactorsClosed)
+            bool requestValid = true;
+            switch (hvRequestedState)
+            {
+            case STATE_READY:
+                requestValid = ignitionOn;
+                break;
+            case STATE_CONDITIONING:
+                requestValid = remotePreconditioningRequested;
+                break;
+            case STATE_CHARGE:
+                requestValid = chargerPlugged || manualCharge;
+                break;
+            default:
+                break;
+            }
+
+            if (!requestValid)
+            {
+                hvRequestPending = false; // cancel request if conditions change
+            }
+            else if (hvContactorsClosed)
             {
                 hvRequestPending = false;
                 TransitionTo(hvRequestedState);
+                return;
             }
-            return; // hold current state until contactors closed
+            else
+            {
+                return; // hold current state until contactors closed
+            }
         }
 
         switch (state)

--- a/src/teensyBMS.cpp
+++ b/src/teensyBMS.cpp
@@ -35,6 +35,10 @@ void TeensyBMS::SetCanInterface(CanHardware* c) {
 }
 
 void TeensyBMS::DecodeCAN(int id, uint8_t* data) {
+    // Store diagnostics for the unit tests/stubs
+    Param::SetInt(Param::BMS_DecodeCanCalled, 1);
+    Param::SetInt(Param::BMS_LastCanId, id);
+
     switch (id) {
         case 0x41A: parseMsg1(data); break;
         case 0x41B: parseMsg2(data); break;


### PR DESCRIPTION
## Summary
- avoid indefinitely waiting for HV contactor feedback
- record CAN decode diagnostics for tests

## Testing
- `make Test`

------
https://chatgpt.com/codex/tasks/task_e_6883dd245024832bbb36334fcee2fac6