### PR TITLE
Add HV request status params and clean up BMS debug

### DIFF
--- a/include/lvdu.h
+++ b/include/lvdu.h
@@ -521,6 +521,9 @@ private:
             connectHV = 1;
         }
         Param::SetInt(Param::LVDU_connectHVcommand, connectHV);
+
+        Param::SetInt(Param::LVDU_hv_request_pending, hvRequestPending ? 1 : 0);
+        Param::SetInt(Param::LVDU_hv_contactors_closed, hvContactorsClosed ? 1 : 0);
     }
 };
 

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -133,10 +133,6 @@
    VALUE_ENTRY(BMS_CONT_PositiveInput, "On/Off", 2225)                                    \
    VALUE_ENTRY(BMS_CONT_PrechargeInput, "On/Off", 2226)                                   \
    VALUE_ENTRY(BMS_CONT_SupplyVoltageAvailable, "On/Off", 2227)                           \
-   VALUE_ENTRY(BMS_SetCanInterfaceCalled, YESNO, 2228)                                    \
-   VALUE_ENTRY(BMS_DecodeCanCalled, YESNO, 2229)                                          \
-   VALUE_ENTRY(BMS_LastCanId, "ID", 2230)                                                 \
-                                                                                          \
    PARAM_ENTRY(CAT_HEATER, heater_flap_threshold, "Raw ADC", 0, 4095, 1000, 113)          \
    PARAM_ENTRY(CAT_HEATER, heater_active_manual, "0=Auto, 1=ManualON", 0, 1, 0, 111)      \
    PARAM_ENTRY(CAT_HEATER, heater_contactor_on_delay, "ms", 0, 10000, 2000, 112)          \
@@ -166,6 +162,10 @@
                                                                                           \
    VALUE_ENTRY(LVDU_forceVCUsShutdown, "On/Off", 2162)                                    \
    VALUE_ENTRY(LVDU_connectHVcommand, "On/Off", 2163)                                     \
+   VALUE_ENTRY(LVDU_hv_request_pending, "On/Off", 2167)\
+          \
+   VALUE_ENTRY(LVDU_hv_contactors_closed, "On/Off", 2168)\
+          \
                                                                                           \
    VALUE_ENTRY(eps_state, EPS_STATE, 2164)                                                \
    VALUE_ENTRY(eps_ignition_out, "On/Off", 2165)                                          \

--- a/src/teensyBMS.cpp
+++ b/src/teensyBMS.cpp
@@ -31,13 +31,10 @@ void TeensyBMS::SetCanInterface(CanHardware* c) {
     can->RegisterUserMessage(0x41D); // MSG4: SOC/SOH
     can->RegisterUserMessage(0x41E); // MSG5: HMI
 
-    Param::SetInt(Param::BMS_SetCanInterfaceCalled, 1);
 }
 
 void TeensyBMS::DecodeCAN(int id, uint8_t* data) {
-    // Store diagnostics for the unit tests/stubs
-    Param::SetInt(Param::BMS_DecodeCanCalled, 1);
-    Param::SetInt(Param::BMS_LastCanId, id);
+    // Store diagnostics for the unit tests/stubs (removed params)
 
     switch (id) {
         case 0x41A: parseMsg1(data); break;

--- a/test/stubs/params.h
+++ b/test/stubs/params.h
@@ -30,13 +30,12 @@ public:
         BMS_CONT_PositiveInput,
         BMS_CONT_PrechargeInput,
         BMS_CONT_SupplyVoltageAvailable,
-        BMS_SetCanInterfaceCalled,
-        BMS_DecodeCanCalled,
-        BMS_LastCanId,
         LVDU_vehicle_state,
         manual_charge_mode,
         LVDU_forceVCUsShutdown,
         LVDU_connectHVcommand,
+        LVDU_hv_request_pending,
+        LVDU_hv_contactors_closed,
         hv_comfort_functions_allowed
     };
     static void SetFloat(int, float) {}

--- a/test/test_teensyBMS.cpp
+++ b/test/test_teensyBMS.cpp
@@ -52,13 +52,9 @@ int main() {
         assert(can.lastData[6] == 0);
         assert(can.lastData[7] == 0); // CRC from stub
 
-        // Test DecodeCAN updates parameters
-        Param::SetInt(Param::BMS_DecodeCanCalled, 0);
-        Param::SetInt(Param::BMS_LastCanId, 0);
+        // Test DecodeCAN runs without errors
         uint8_t data[8] = {0};
         bms.DecodeCAN(0x41A, data);
-        assert(Param::GetInt(Param::BMS_DecodeCanCalled) == 1);
-        assert(Param::GetInt(Param::BMS_LastCanId) == 0x41A);
     }
     return 0;
 }


### PR DESCRIPTION
## Summary
- add `LVDU_hv_request_pending` and `LVDU_hv_contactors_closed` runtime values
- remove unused BMS debug values
- propagate new runtime values in `LVDU`
- adjust tests and param stubs

## Testing
- `cd test && make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_6883f866d4b4832b9de2f79a7f414d16