### PR TITLE
Add manual standby override for LVDU

### DIFF
--- a/include/lvdu.h
+++ b/include/lvdu.h
@@ -147,6 +147,24 @@ private:
 
     void UpdateState()
     {
+        bool manualStandby = Param::GetInt(Param::manual_standby_mode);
+        if (manualStandby)
+        {
+            hvManager.SetHVRequest(false);
+            forceStandbyActive = false;
+            forceStandbyTimer = 0;
+            forceSleepActive = false;
+            forceSleepTimer = 0;
+            standbyTimeoutCounter = 0;
+            chargeDoneCounter = 0;
+
+            if (state != STATE_STANDBY)
+                TransitionTo(STATE_STANDBY);
+
+            manualChargePrev = false;
+            return;
+        }
+
         // Manual override: detect rising/falling edge of manual_charge_mode
         bool manualCharge = Param::GetInt(Param::manual_charge_mode);
         if (manualCharge && !manualChargePrev && state != STATE_CHARGE)

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -64,6 +64,7 @@
    PARAM_ENTRY(CAT_LVDU, LVDU_12v_low_threshold, "V", 8.0, 13.5, 11.0, 116)               \
    PARAM_ENTRY(CAT_LVDU, LVDU_hv_low_threshold, "V", 100.0, 800.0, 200.0, 117)            \
    PARAM_ENTRY(CAT_LVDU, manual_charge_mode, YESNO, 0, 1, 0, 118)                         \
+   PARAM_ENTRY(CAT_LVDU, manual_standby_mode, YESNO, 0, 1, 0, 121)                        \
                                                                                           \
    PARAM_ENTRY(CAT_LVDU, charge_done_current, "A", 0, 10, 0.5, 119)                       \
                                                                                           \

--- a/test/stubs/params.h
+++ b/test/stubs/params.h
@@ -32,6 +32,7 @@ public:
         BMS_CONT_SupplyVoltageAvailable,
         LVDU_vehicle_state,
         manual_charge_mode,
+        manual_standby_mode,
         LVDU_forceVCUsShutdown,
         LVDU_connectHVcommand,
         LVDU_hv_request_pending,


### PR DESCRIPTION
## Summary
- add a manual standby mode parameter to the LVDU parameter list and test stubs
- force the LVDU state machine to remain in standby with HV open whenever the override is enabled

## Testing
- make Test

------
https://chatgpt.com/codex/tasks/task_e_68d728342f04832bbff9f46b1462d60c