### PR TITLE
Guard MLB_CHARGER_STANDALONE macro definition

### DIFF
--- a/src/vw_mlb_charger.cpp
+++ b/src/vw_mlb_charger.cpp
@@ -20,7 +20,9 @@
 #include <vw_mlb_charger.h>
 #include "params.h"
 
+#ifndef MLB_CHARGER_STANDALONE
 #define MLB_CHARGER_STANDALONE // Comment out to run in Zombie integrated mode
+#endif
 
 /*CAN send information flow path:
 


### PR DESCRIPTION
## Summary
- wrap MLB_CHARGER_STANDALONE in an include guard so external definitions are respected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68def526cae8832b812e458aea4828f4