### PR TITLE
Use MLB plug status to manage LVDU charge transitions

### DIFF
--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -179,7 +179,6 @@
                                                                                           \
    PARAM_ENTRY(CAT_LVDU, LVDU_12v_low_threshold, "V", 8.0, 13.5, 11.0, 116)               \
    PARAM_ENTRY(CAT_LVDU, LVDU_hv_low_threshold, "V", 100.0, 800.0, 200.0, 117)            \
-   PARAM_ENTRY(CAT_LVDU, manual_charge_mode, YESNO, 0, 1, 0, 118)                         \
    PARAM_ENTRY(CAT_LVDU, manual_standby_mode, YESNO, 0, 1, 0, 121)                        \
    PARAM_ENTRY(CAT_LVDU, charge_done_current, "A", 0, 10, 0.5, 119)                       \
    PARAM_ENTRY(CAT_LVDU, charge_done_delay, "s", 0, 600, 30, 120)                         \

--- a/test/stubs/params.h
+++ b/test/stubs/params.h
@@ -31,7 +31,7 @@ public:
         BMS_CONT_PrechargeInput,
         BMS_CONT_SupplyVoltageAvailable,
         LVDU_vehicle_state,
-        manual_charge_mode,
+        mlb_chr_PlugStatus,
         manual_standby_mode,
         LVDU_forceVCUsShutdown,
         LVDU_connectHVcommand,


### PR DESCRIPTION
## Summary
- drive the LVDU charge state transitions from the MLB plug status parameter
- remove the unused manual charge mode parameter and related stub definition

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0182acb18832b8bb56877dade10c0