### PR TITLE
Add standby shutdown checks during BMS balancing

### DIFF
--- a/include/lvdu.h
+++ b/include/lvdu.h
@@ -125,7 +125,7 @@ private:
         float hvVoltage = Param::GetFloat(Param::BMS_PackVoltage);
         bmsValid = Param::GetInt(Param::BMS_DataValid);
         contState = Param::GetInt(Param::BMS_CONT_State);
-        bmsBalancing = Param::GetInt(Param::BMS_BalancingAnyActive);
+        bmsBalancing = bmsValid && Param::GetInt(Param::BMS_BalancingAnyActive);
 
         // Still update for possible custom behavior
         chargerPlugged = false; // TODO: Add real charger detection via CAN
@@ -212,6 +212,12 @@ private:
                 if (bmsBalancing)
                 {
                     standbyTimeoutCounter = 0; // Stay awake while BMS is balancing
+
+                    // If CAN comms to the BMS fail or LV drops too low while balancing, shut down
+                    if (!bmsValid || is12VTooLow)
+                    {
+                        TransitionTo(STATE_SLEEP);
+                    }
                 }
                 else if (++standbyTimeoutCounter >= LVDU_STANDBY_TIMEOUT_STEPS)
                 {

--- a/src/teensyBMS.cpp
+++ b/src/teensyBMS.cpp
@@ -131,8 +131,8 @@ void TeensyBMS::Task100Ms() {
     Param::SetFloat(Param::BMS_PackVoltage, packVoltage);
     Param::SetFloat(Param::BMS_DeltaCellVoltage, deltaVoltage);
     Param::SetFloat(Param::BMS_BalancingVoltage, balancingVoltage);
-    Param::SetInt(Param::BMS_BalancingActive, balancingActive);
-    Param::SetInt(Param::BMS_BalancingAnyActive, anyBalancing);
+    Param::SetInt(Param::BMS_BalancingActive, bmsValid && balancingActive);
+    Param::SetInt(Param::BMS_BalancingAnyActive, bmsValid && anyBalancing);
     Param::SetFloat(Param::BMS_ActualCurrent, actualCurrent);
     Param::SetFloat(Param::BMS_SOC, soc);
     Param::SetFloat(Param::BMS_PackPower, packPower);


### PR DESCRIPTION
## Summary
- ensure the LVDU transitions to sleep when BMS CAN data is lost during a balancing hold
- trigger a shutdown if the 12V rail falls below the configured threshold while balancing in standby
- gate the BMS balancing flags on data validity so stale values cannot keep the LVDU awake

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e019a6c110832bb1ba506c43d180d8