### PR TITLE
Add mVCU CAN integration to report AC input and max charge power (CAN ID 0x438)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ LDFLAGS    = -Llibopencm3/lib -T$(LDSCRIPT) -march=armv7 -nostartfiles -Wl,--gc-
 OBJSL = main.o hwinit.o stm32scheduler.o params.o terminal.o terminal_prj.o \
         my_string.o digio.o sine_core.o my_fp.o printf.o anain.o \
         param_save.o errormessage.o stm32_can.o canhardware.o canmap.o cansdo.o \
-        picontroller.o terminalcommands.o TeslaDCDC.o teensyBMS.o \
+        picontroller.o terminalcommands.o TeslaDCDC.o teensyBMS.o mVCUIntegration.o \
         vw_mlb_charger.o vag_utils.o
 
 

--- a/docs/mVCU_Integration.md
+++ b/docs/mVCU_Integration.md
@@ -1,0 +1,37 @@
+# mVCU Integration
+
+Diese Dokumentation beschreibt die aktuell implementierte CAN-Kommunikation zwischen Zombie-Slave und dem Main-Steuergerät (mVCU).
+
+## Ziel
+
+An das Main-Steuergerät werden zyklisch folgende Leistungswerte übertragen:
+
+1. **Aktuelle Ladeleistung (als AC-Eingangsleistungs-Schätzwert)**
+2. **Maximal mögliche Ladeleistung**
+
+## CAN Nachricht (TX)
+
+- **CAN-ID:** `0x438`
+- **DLC:** `8`
+- **Sendeintervall:** `100 ms`
+- **Endianness:** Little Endian
+
+### Signalbelegung
+
+| Byte | Signal | Typ | Einheit | Quelle |
+|---|---|---|---|---|
+| 0..3 | `actualChargePower` | `uint32` | W | `(mlb_chr_LAD_IstSpannung_HV * mlb_chr_LAD_IstStrom_HV) + mlb_chr_LAD_Verlustleistung` |
+| 4..7 | `maxChargePower` | `uint32` | W | `mlb_chr_HVLM_MaxLadeLeistung` |
+
+## Zusätzlicher MLB-Parameter
+
+Neu hinzugefügt wurde der Diagnose-/Messwert:
+
+- `mlb_chr_LAD_Verlustleistung` (W)
+
+Dieser Wert wird aus dem MLB-CAN-Decode übernommen und für die Berechnung der AC-Eingangsleistung verwendet.
+
+## Hinweise
+
+- Negative Werte werden vor dem Versand auf `0` begrenzt.
+- Die Implementierung ist in einer separaten Device-Klasse `mVCUIntegration` umgesetzt.

--- a/include/mVCUIntegration.h
+++ b/include/mVCUIntegration.h
@@ -1,0 +1,17 @@
+#ifndef MVCUINTEGRATION_H
+#define MVCUINTEGRATION_H
+
+#include <stdint.h>
+#include "canhardware.h"
+
+class mVCUIntegration
+{
+public:
+    void SetCanInterface(CanHardware* c);
+    void Task100Ms();
+
+private:
+    CanHardware* can = nullptr;
+};
+
+#endif // MVCUINTEGRATION_H

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -48,7 +48,7 @@
    3. Display values
  */
 // Next param id (increase when adding new parameter!): 167
-// Next value Id: 2337
+// Next value Id: 2338
 /*              category     name         unit       min     max     default id */
 #define PARAM_LIST                                                                        \
    PARAM_ENTRY(CAT_COMM, canspeed, CANSPEEDS, 0, 4, 2, 1)                                 \
@@ -115,6 +115,7 @@
    VALUE_ENTRY(mlb_chr_LAD_IstSpannung_HV, "V", 2314)                                     \
    VALUE_ENTRY(mlb_chr_LAD_IstStrom_HV, "A", 2315)                                        \
    VALUE_ENTRY(mlb_chr_LAD_Temperatur, "°C", 2316)                                        \
+   VALUE_ENTRY(mlb_chr_LAD_Verlustleistung, "W", 2337)                                     \
    VALUE_ENTRY(mlb_chr_HVLM_Ladesystemhinweise, HVLM_LADESYSTEMHINWEISE, 2317)            \
    VALUE_ENTRY(mlb_chr_HVLM_Zustand_LED, HVLM_ZUSTAND_LED, 2318)                          \
    VALUE_ENTRY(mlb_chr_HVLM_MaxStrom_Netz, "Unit_Amper", 2319)                            \

--- a/src/mVCUIntegration.cpp
+++ b/src/mVCUIntegration.cpp
@@ -1,0 +1,53 @@
+#include "mVCUIntegration.h"
+#include "params.h"
+
+#define MVCU_CHARGE_POWER_STATUS_ID 0x438
+
+void mVCUIntegration::SetCanInterface(CanHardware* c)
+{
+    can = c;
+}
+
+void mVCUIntegration::Task100Ms()
+{
+    if (!can)
+    {
+        return;
+    }
+
+    int dcChargePowerW = Param::GetInt(Param::mlb_chr_LAD_IstSpannung_HV) * Param::GetInt(Param::mlb_chr_LAD_IstStrom_HV);
+    if (dcChargePowerW < 0)
+    {
+        dcChargePowerW = 0;
+    }
+
+    int chargerLossPowerW = Param::GetInt(Param::mlb_chr_LAD_Verlustleistung);
+    if (chargerLossPowerW < 0)
+    {
+        chargerLossPowerW = 0;
+    }
+
+    const int acInputPowerW = dcChargePowerW + chargerLossPowerW;
+
+    int maxChargePowerW = Param::GetInt(Param::mlb_chr_HVLM_MaxLadeLeistung);
+    if (maxChargePowerW < 0)
+    {
+        maxChargePowerW = 0;
+    }
+
+    uint8_t bytes[8] = {0};
+    const uint32_t actualChargePower = static_cast<uint32_t>(acInputPowerW);
+    const uint32_t maxChargePower = static_cast<uint32_t>(maxChargePowerW);
+
+    bytes[0] = static_cast<uint8_t>(actualChargePower & 0xFFU);
+    bytes[1] = static_cast<uint8_t>((actualChargePower >> 8) & 0xFFU);
+    bytes[2] = static_cast<uint8_t>((actualChargePower >> 16) & 0xFFU);
+    bytes[3] = static_cast<uint8_t>((actualChargePower >> 24) & 0xFFU);
+
+    bytes[4] = static_cast<uint8_t>(maxChargePower & 0xFFU);
+    bytes[5] = static_cast<uint8_t>((maxChargePower >> 8) & 0xFFU);
+    bytes[6] = static_cast<uint8_t>((maxChargePower >> 16) & 0xFFU);
+    bytes[7] = static_cast<uint8_t>((maxChargePower >> 24) & 0xFFU);
+
+    can->Send(MVCU_CHARGE_POWER_STATUS_ID, bytes, 8);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,6 +48,7 @@
 #include "lvdu.h"
 #include "eps.h"
 #include "vw_mlb_charger.h"
+#include "mVCUIntegration.h"
 
 #define PRINT_JSON 0
 
@@ -66,6 +67,7 @@ static VacuumPump vacuumPump;
 static LVDU lvdu;
 static EPS eps;
 static VWMLBClass mlbCharger;
+static mVCUIntegration mvcuIntegration;
 
 // Whenever the user clears mapped can messages or changes the
 // CAN interface of a device, this will be called by the CanHardware module
@@ -78,6 +80,7 @@ static void SetCanFilters()
    DCDCTesla.SetCanInterface(dcdc_can);
    teensyBms.SetCanInterface(bms_can);
    mlbCharger.SetCanInterface(charger_can);
+   mvcuIntegration.SetCanInterface(charger_can);
 
    canInterface[0]->RegisterUserMessage(0x601); // CanSDO
    canInterface[1]->RegisterUserMessage(0x601); // CanSDO
@@ -122,6 +125,7 @@ static void Ms100Task(void)
    lvdu.Task100Ms();
    eps.Task100Ms();
    mlbCharger.Task100Ms();
+   mvcuIntegration.Task100Ms();
 }
 
 // sample 10 ms task

--- a/src/vw_mlb_charger.cpp
+++ b/src/vw_mlb_charger.cpp
@@ -273,6 +273,7 @@ void VWMLBClass::TagParams() // To make code portable between standalone (more p
     Param::SetInt(Param::mlb_chr_LAD_IstSpannung_HV, charger_status.LAD_IstSpannung_HV);
     Param::SetInt(Param::mlb_chr_LAD_IstStrom_HV, static_cast<int>(charger_status.LAD_IstStrom_HV));
     Param::SetInt(Param::mlb_chr_LAD_Temperatur, charger_status.LAD_Temperatur);
+    Param::SetInt(Param::mlb_chr_LAD_Verlustleistung, charger_status.LAD_Verlustleistung);
     Param::SetInt(Param::mlb_chr_HVLM_Ladesystemhinweise, charger_status.HVLM_Ladesystemhinweise);
     Param::SetInt(Param::mlb_chr_HVLM_Zustand_LED, charger_status.HVLM_Zustand_LED);
     Param::SetInt(Param::mlb_chr_HVLM_MaxStrom_Netz, static_cast<int>(charger_status.HVLM_MaxStrom_Netz));


### PR DESCRIPTION
### Motivation

- Provide a simple integration that reports charger AC input power and maximum allowed charge power to the main VCU over CAN.
- Preserve charger loss as a separate diagnostic/value so the AC input estimate can include losses.
- Run the integration on the existing 100 ms scheduler to match existing CAN periodic behavior.

### Description

- Added a new device class `mVCUIntegration` (`include/mVCUIntegration.h`, `src/mVCUIntegration.cpp`) that computes AC input power and max charge power and sends them as an 8-byte little-endian CAN message on ID `0x438` every 100 ms.  The payload contains `actualChargePower` (uint32, bytes 0..3) and `maxChargePower` (uint32, bytes 4..7).
- Added a new parameter/value `mlb_chr_LAD_Verlustleistung` (W) in `include/param_prj.h` and populated it from charger status in `src/vw_mlb_charger.cpp` so losses are included in the AC input calculation.
- Integrated the module into the main application by instantiating `mvcuIntegration` in `src/main.cpp`, wiring its CAN interface in `SetCanFilters`, and calling `Task100Ms()` from the 100 ms scheduler loop.
- Added build and project integration by updating the `Makefile` to compile `mVCUIntegration.o` and included a documentation file `docs/mVCU_Integration.md` describing the CAN format and behavior.

### Testing

- Cross-compiled the firmware with the project's toolchain using `make`, and the build and link completed successfully with the added files.
- No automated unit tests were added; existing build is unchanged beyond the new module and parameter and no regressions were observed during the build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2da6d24d4832b9c2c422b4336880e)