### PR TITLE
Add heater CAN status and CRC/counter-protected mVCU contactor control

### DIFF
--- a/docs/mVCU_Integration.md
+++ b/docs/mVCU_Integration.md
@@ -23,6 +23,38 @@ An das Main-Steuergerät werden zyklisch folgende Leistungswerte übertragen:
 | 0..3 | `actualChargePower` | `uint32` | W | `(mlb_chr_LAD_IstSpannung_HV * mlb_chr_LAD_IstStrom_HV) + mlb_chr_LAD_Verlustleistung` |
 | 4..7 | `maxChargePower` | `uint32` | W | `mlb_chr_HVLM_MaxLadeLeistung` |
 
+## Heater Status Nachricht (TX)
+
+- **CAN-ID:** `0x439`
+- **DLC:** `8`
+- **Sendeintervall:** `100 ms`
+- **Sicherheitskonzept:** Byte 6 enthält einen 4-Bit Rolling Counter (0..15), Byte 7 enthält CRC8 (STM32 CRC Low-Byte über Byte 0..6)
+
+| Byte | Signal | Typ | Bedeutung |
+|---|---|---|---|
+| 0 | `heater_active` | `uint8` | 0 = aus, 1 = aktiv |
+| 1 | `heater_contactor_feedback_in` | `uint8` | 0 = offen, 1 = geschlossen |
+| 2 | `heater_fault` | `uint8` | 0 = OK, 1 = Fehler |
+| 3 | `heater_thermal_switch_in` | `uint8` | 0 = offen/Übertemp, 1 = geschlossen/OK |
+| 4 | `heater_contactor_out` | `uint8` | 0 = aus, 1 = ein |
+| 5 | `heater_can_contactor_request` | `uint8` | letzter gültiger mVCU-Heater-Anforderungsstatus |
+| 6 | `counter` | `uint8` | low nibble 0..15 |
+| 7 | `crc` | `uint8` | CRC8 |
+
+## Heater Contactor Control Nachricht (RX)
+
+- **CAN-ID:** `0x43A`
+- **DLC:** `8` (Frames mit DLC < 8 werden verworfen)
+- **Sicherheitskonzept:** CRC + Rolling Counter (nur bei gültigem CRC und gültigem Zähler wird die Anforderung übernommen)
+- **Timeout:** Ohne gültige Nachricht für 500 ms wird die CAN-Anforderung auf 0 zurückgesetzt.
+
+| Byte | Signal | Typ | Bedeutung |
+|---|---|---|---|
+| 0 | `heater_close_request` | `uint8` | Bit0: 1 = Heizungs-Schütz anfordern (wie analoges Flapsignal), 0 = aus |
+| 1..5 | `reserved` | `uint8` | reserviert |
+| 6 | `counter` | `uint8` | low nibble 0..15 |
+| 7 | `crc` | `uint8` | CRC8 |
+
 ## Zusätzlicher MLB-Parameter
 
 Neu hinzugefügt wurde der Diagnose-/Messwert:
@@ -35,3 +67,4 @@ Dieser Wert wird aus dem MLB-CAN-Decode übernommen und für die Berechnung der 
 
 - Negative Werte werden vor dem Versand auf `0` begrenzt.
 - Die Implementierung ist in einer separaten Device-Klasse `mVCUIntegration` umgesetzt.
+- Die CAN-Heater-Anforderung erweitert die bestehende Heater-Logik um einen zusätzlichen Triggerpfad (parallel zu manuellem Override und analogem Flapsignal).

--- a/include/heater.h
+++ b/include/heater.h
@@ -129,7 +129,8 @@ public:
         Param::SetInt(Param::heater_fault, fault_present ? 1 : 0);
 
         // Main control logic
-        bool heater_should_run = (manual_override || flap_signal > flap_threshold);
+        bool can_contactor_request = Param::GetInt(Param::heater_can_contactor_request) != 0;
+        bool heater_should_run = (manual_override || flap_signal > flap_threshold || can_contactor_request);
 
         // Detect thermal switch closing (rising edge)
         if (thermal_closed && thermal_switch_was_open)

--- a/include/mVCUIntegration.h
+++ b/include/mVCUIntegration.h
@@ -8,10 +8,19 @@ class mVCUIntegration
 {
 public:
     void SetCanInterface(CanHardware* c);
+    void DecodeCAN(int id, uint8_t* data, uint8_t dlc);
     void Task100Ms();
 
 private:
+    bool CheckCrc(const uint8_t* data) const;
+    bool ValidateCounter(uint8_t counter);
+
     CanHardware* can = nullptr;
+    uint8_t txCounter = 0;
+    bool heaterCanCloseRequest = false;
+    bool haveSeenValidCounter = false;
+    uint8_t lastRxCounter = 0;
+    uint8_t rxTimeoutTicks = 0;
 };
 
 #endif // MVCUINTEGRATION_H

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -176,6 +176,7 @@
    VALUE_ENTRY(heater_thermal_switch_in, "0=Overtemp, 1=OK", 2131)                        \
    VALUE_ENTRY(heater_contactor_feedback_in, "0=Open, 1=Closed", 2132)                    \
    VALUE_ENTRY(heater_contactor_out, "0=Off, 1=On", 2133)                                 \
+   VALUE_ENTRY(heater_can_contactor_request, "0=Off, 1=On", 2170)                         \
    VALUE_ENTRY(heater_off_confirmed, "0=No, 1=Yes", 2142)                                 \
    VALUE_ENTRY(heater_fault, "0=OK, 1=Fault", 2143)                                       \
    VALUE_ENTRY(hv_comfort_functions_allowed, "0=No, 1=Yes", 2144)                         \

--- a/src/mVCUIntegration.cpp
+++ b/src/mVCUIntegration.cpp
@@ -1,11 +1,80 @@
 #include "mVCUIntegration.h"
 #include "params.h"
+#include <libopencm3/stm32/crc.h>
+#include <string.h>
 
 #define MVCU_CHARGE_POWER_STATUS_ID 0x438
+#define MVCU_HEATER_STATUS_ID 0x439
+#define MVCU_HEATER_CONTROL_ID 0x43A
+#define MVCU_RX_TIMEOUT_TICKS_100MS 5
 
 void mVCUIntegration::SetCanInterface(CanHardware* c)
 {
+    if (c == nullptr)
+    {
+        can = nullptr;
+        heaterCanCloseRequest = false;
+        haveSeenValidCounter = false;
+        rxTimeoutTicks = 0;
+        Param::SetInt(Param::heater_can_contactor_request, 0);
+        return;
+    }
+
     can = c;
+    can->RegisterUserMessage(MVCU_HEATER_CONTROL_ID);
+}
+
+bool mVCUIntegration::CheckCrc(const uint8_t* data) const
+{
+    uint32_t buf[2] = {0, 0};
+    memcpy(buf, data, 8);
+    buf[1] &= 0x00FFFFFF; // clear CRC byte (byte 7)
+    crc_reset();
+    const uint32_t crc = crc_calculate_block(buf, 2) & 0xFFU;
+    return crc == data[7];
+}
+
+bool mVCUIntegration::ValidateCounter(uint8_t counter)
+{
+    counter &= 0x0FU;
+
+    if (!haveSeenValidCounter)
+    {
+        haveSeenValidCounter = true;
+        lastRxCounter = counter;
+        return true;
+    }
+
+    const uint8_t expectedCounter = static_cast<uint8_t>((lastRxCounter + 1U) & 0x0FU);
+    if (counter != expectedCounter)
+    {
+        return false;
+    }
+
+    lastRxCounter = counter;
+    return true;
+}
+
+void mVCUIntegration::DecodeCAN(int id, uint8_t* data, uint8_t dlc)
+{
+    if (id != MVCU_HEATER_CONTROL_ID || data == nullptr || dlc < 8)
+    {
+        return;
+    }
+
+    if (!CheckCrc(data))
+    {
+        return;
+    }
+
+    if (!ValidateCounter(data[6] & 0x0FU))
+    {
+        return;
+    }
+
+    heaterCanCloseRequest = (data[0] & 0x01U) != 0U;
+    rxTimeoutTicks = MVCU_RX_TIMEOUT_TICKS_100MS;
+    Param::SetInt(Param::heater_can_contactor_request, heaterCanCloseRequest ? 1 : 0);
 }
 
 void mVCUIntegration::Task100Ms()
@@ -50,4 +119,32 @@ void mVCUIntegration::Task100Ms()
     bytes[7] = static_cast<uint8_t>((maxChargePower >> 24) & 0xFFU);
 
     can->Send(MVCU_CHARGE_POWER_STATUS_ID, bytes, 8);
+
+    if (rxTimeoutTicks > 0)
+    {
+        rxTimeoutTicks--;
+    }
+    if (rxTimeoutTicks == 0)
+    {
+        heaterCanCloseRequest = false;
+        Param::SetInt(Param::heater_can_contactor_request, 0);
+    }
+
+    uint8_t heaterStatusBytes[8] = {0};
+    heaterStatusBytes[0] = static_cast<uint8_t>(Param::GetInt(Param::heater_active) ? 1 : 0);
+    heaterStatusBytes[1] = static_cast<uint8_t>(Param::GetInt(Param::heater_contactor_feedback_in) ? 1 : 0);
+    heaterStatusBytes[2] = static_cast<uint8_t>(Param::GetInt(Param::heater_fault) ? 1 : 0);
+    heaterStatusBytes[3] = static_cast<uint8_t>(Param::GetInt(Param::heater_thermal_switch_in) ? 1 : 0);
+    heaterStatusBytes[4] = static_cast<uint8_t>(Param::GetInt(Param::heater_contactor_out) ? 1 : 0);
+    heaterStatusBytes[5] = static_cast<uint8_t>(Param::GetInt(Param::heater_can_contactor_request) ? 1 : 0);
+    heaterStatusBytes[6] = txCounter & 0x0FU;
+
+    uint32_t crcBuf[2] = {0, 0};
+    memcpy(crcBuf, heaterStatusBytes, sizeof(crcBuf));
+    crcBuf[1] &= 0x00FFFFFF; // clear CRC byte (byte 7)
+    crc_reset();
+    heaterStatusBytes[7] = static_cast<uint8_t>(crc_calculate_block(crcBuf, 2) & 0xFFU);
+
+    can->Send(MVCU_HEATER_STATUS_ID, heaterStatusBytes, 8);
+    txCounter = static_cast<uint8_t>((txCounter + 1U) & 0x0FU);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,6 +92,7 @@ static bool CanCallback(uint32_t id, uint32_t data[2], uint8_t dlc) // This is w
    DCDCTesla.DecodeCAN(id, (uint8_t *)data);
    teensyBms.DecodeCAN(id, (uint8_t *)data);
    mlbCharger.DecodeCAN(id, data);
+   mvcuIntegration.DecodeCAN(id, (uint8_t *)data, dlc);
    return false;
 }
 


### PR DESCRIPTION
### Motivation
- Provide a CAN-based, end-to-end protected way for the main VCU to request the heater contactor to close (behaves like the analog trigger) and to publish heater status for observability.
- Ensure safety by validating incoming requests with CRC and a rolling counter and by timing out stale requests.

### Description
- Added `mVCUIntegration::DecodeCAN(int id, uint8_t* data, uint8_t dlc)` with CRC (`STM32 CRC`), 4-bit rolling-counter validation and an RX timeout; registered RX ID `0x43A` in `SetCanInterface`.
- Publish a new heater status TX frame `0x439` every 100 ms containing heater bits, a 4-bit counter and CRC, and keep the existing charge-power TX `0x438` intact.
- Integrated `mvcuIntegration.DecodeCAN(...)` into the global CAN callback so incoming heater control messages are processed.
- Extended heater run logic to accept the validated CAN request (`Param::heater_can_contactor_request`) in parallel with manual override and flap threshold, added the new parameter `heater_can_contactor_request`, and documented both TX/RX message formats in `docs/mVCU_Integration.md`.

### Testing
- Ran unit/integration tests with `make -C test -j4` which completed successfully.
- Attempted full firmware build with `make -j4` but it could not complete in this environment because `arm-none-eabi-g++` is not available (build failed due to missing toolchain).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d26ac09098832bae2483113ec4fc5f)